### PR TITLE
fix(tooltip): enable dark mode

### DIFF
--- a/assets/styles/themes/_dark.scss
+++ b/assets/styles/themes/_dark.scss
@@ -105,9 +105,9 @@
   --popover-bg                 : var(--body-bg);
   --popover-border             : var(--border);
   --popover-text               : var(--body-text);
-  --tooltip-bg                 : var(--tag-bg);
-  --tooltip-border             : var(--tag-primary);
-  --tooltip-text               : var(--tag-primary);
+  --tooltip-bg                 : #{$darkest};
+  --tooltip-border             : #{$darkest};
+  --tooltip-text               : #{$lightest};
 
   --tabbed-border              : #{$medium};
   --tabbed-container-bg        : #{$darkest};

--- a/assets/styles/themes/_light.scss
+++ b/assets/styles/themes/_light.scss
@@ -129,9 +129,9 @@ $selected: rgba($primary, .5);
   --popover-border             : var(--border);
   --popover-text               : var(--body-text);
   --popover-border-radius      : var(--border-radius);
-  --tooltip-bg                 : var(--tag-bg);
-  --tooltip-border             : var(--tag-primary);
-  --tooltip-text               : var(--tag-primary);
+  --tooltip-bg                 : #{$darkest};
+  --tooltip-border             : #{$darkest};
+  --tooltip-text               : #{$lightest};
 
   --tabbed-border              : #{$medium};
   --tabbed-container-bg        : #f4f5fa;

--- a/edit/harvester.cattle.io.virtualmachineimage.vue
+++ b/edit/harvester.cattle.io.virtualmachineimage.vue
@@ -83,7 +83,7 @@ export default {
           <template v-slot:label>
             <div>
               <span class="label">Enter Url</span>
-              <el-tooltip v-if="isCreate" placement="top" effect="light">
+              <el-tooltip v-if="isCreate" placement="top" effect="dark">
                 <div slot="content">
                   Protip: supports the <code>raw</code> and <code>qcow2</code> image formats which are supported by <a href="https://www.qemu.org/docs/master/system/images.html#disk-image-file-formats" target="_blank">qemu</a>.
                   Bootable ISO images can also be used and are treated like <code>raw</code> images.

--- a/edit/kubevirt.io.virtualmachine/index.vue
+++ b/edit/kubevirt.io.virtualmachine/index.vue
@@ -260,7 +260,7 @@ export default {
       <template v-slot:label>
         <div>
           <span class="label">Host Name</span>
-          <el-tooltip v-if="isCreate" placement="top" effect="light">
+          <el-tooltip v-if="isCreate" placement="top" effect="dark">
             <div slot="content">
               Give an identifying name you will remember them by. Your hostname name can only contain alphanumeric characters, dashes, and periods.
             </div>


### PR DESCRIPTION
#### Enable dark mode

[https://github.com/rancher/harvester/issues/89](https://github.com/rancher/harvester/issues/89)

- [x]  4. The IP Address copy tooltip's background is transparent that makes the texts overlap 