### PR TITLE
fix: Incorrect "Stopping" status in UI

### DIFF
--- a/models/kubevirt.io.virtualmachine.js
+++ b/models/kubevirt.io.virtualmachine.js
@@ -239,7 +239,7 @@ export default {
     if (!this?.spec) {
       return false;
     }
-    const { running, runStrategy } = this.spec;
+    const { running = null, runStrategy = null } = this.spec;
 
     if (running !== null) {
       return running;


### PR DESCRIPTION
While user indicates the desired state to runStrategy in VM spec, It always
shows "Stopping" status in harvester UI.

example 1: running: false      -> runStrategy: Always
example 2: running: true       -> runStrategy: Always
example 3: runStrategy: Halted -> runStrategy: Always

Signed-off-by: Lin Ma <lma@suse.com>