### PR TITLE
[UI]the vm state should be hide when migrating/aborting

### DIFF
--- a/components/formatter/MigrationState.vue
+++ b/components/formatter/MigrationState.vue
@@ -25,7 +25,13 @@ export default {
     state() {
       return this.vmiResource?.migrationState?.status || '';
     }
-  }
+  },
+
+  watch: {
+    state(neu) {
+      this.$emit('state-changed', neu);
+    }
+  },
 };
 </script>
 

--- a/components/formatter/vmState.vue
+++ b/components/formatter/vmState.vue
@@ -1,5 +1,6 @@
 <script>
 import VMState from '@/components/formatter/BadgeStateFormatter';
+import { VMI } from '@/config/types';
 // import RestoreProgress from '@/components/formatter/restoreProgress';
 
 export default {
@@ -46,6 +47,19 @@ export default {
       const clusterNetwork = this.allClusterNetwork?.[0] || {};
 
       return clusterNetwork?.enable;
+    },
+
+    vmiResource() {
+      const vmiList = this.$store.getters['cluster/all'](VMI) || [];
+      const vmi = vmiList.find( (VMI) => {
+        return VMI?.metadata?.ownerReferences?.[0]?.uid === this.row?.metadata?.uid;
+      });
+
+      return vmi;
+    },
+
+    migrationState() {
+      return this.vmiResource?.migrationState?.status || '';
     }
   }
 };
@@ -54,7 +68,10 @@ export default {
 <template>
   <span>
     <!-- <RestoreProgress :vm="row" /> -->
-    <div class="state">
+    <span v-if="!!migrationState" :class="{'badge-state': true, [vmiResource.migrationStateBackground]: true}">
+      {{ migrationState }}
+    </span>
+    <div v-else class="state">
       <VMState :row="row" />
       <i v-if="NetworkImpassability" v-tooltip="message" class="icon icon-warning icon-lg text-warning" />
     </div>

--- a/components/formatter/vmState.vue
+++ b/components/formatter/vmState.vue
@@ -1,10 +1,10 @@
 <script>
 import VMState from '@/components/formatter/BadgeStateFormatter';
-import { VMI } from '@/config/types';
+import MigrationState from '@/components/formatter/MigrationState';
 // import RestoreProgress from '@/components/formatter/restoreProgress';
 
 export default {
-  components: { VMState },
+  components: { VMState, MigrationState },
   props:      {
     value: {
       type:     String,
@@ -31,6 +31,10 @@ export default {
     }
   },
 
+  data() {
+    return { isMigrating: false };
+  },
+
   computed: {
     NetworkImpassability() {
       const nodeName = this.row?.nodeName;
@@ -48,30 +52,21 @@ export default {
 
       return clusterNetwork?.enable;
     },
+  },
 
-    vmiResource() {
-      const vmiList = this.$store.getters['cluster/all'](VMI) || [];
-      const vmi = vmiList.find( (VMI) => {
-        return VMI?.metadata?.ownerReferences?.[0]?.uid === this.row?.metadata?.uid;
-      });
-
-      return vmi;
-    },
-
-    migrationState() {
-      return this.vmiResource?.migrationState?.status || '';
+  methods: {
+    migrationStateChanged(neu) {
+      this.isMigrating = !!neu;
     }
-  }
+  },
 };
 </script>
 
 <template>
   <span>
     <!-- <RestoreProgress :vm="row" /> -->
-    <span v-if="!!migrationState" :class="{'badge-state': true, [vmiResource.migrationStateBackground]: true}">
-      {{ migrationState }}
-    </span>
-    <div v-else class="state">
+    <MigrationState v-show="isMigrating" :vm-resource="row" @state-changed="migrationStateChanged" />
+    <div v-show="!isMigrating" class="state">
       <VMState :row="row" />
       <i v-if="NetworkImpassability" v-tooltip="message" class="icon icon-warning icon-lg text-warning" />
     </div>

--- a/list/kubevirt.io.virtualmachine/index.vue
+++ b/list/kubevirt.io.virtualmachine/index.vue
@@ -1,7 +1,6 @@
 <script>
 import VmState from '@/components/formatter/vmState';
 import SortableTable from '@/components/SortableTable';
-import MigrationState from '@/components/formatter/MigrationState';
 
 import { STATE, AGE, NAME } from '@/config/table-headers';
 import { HARVESTER_NODE_NETWORK, HARVESTER_CLUSTER_NETWORK, VM, VMI } from '@/config/types';
@@ -16,7 +15,6 @@ export default {
   components: {
     SortableTable,
     VmState,
-    MigrationState,
     BackupModal,
     RestoreModal,
     MigrationModal
@@ -124,7 +122,6 @@ export default {
       <template slot="cell:state" slot-scope="scope" class="state-col">
         <div class="state">
           <VmState class="vmstate" :row="scope.row" :all-node-network="allNodeNetwork" :all-cluster-network="allClusterNetwork" />
-          <MigrationState :vm-resource="scope.row" :show-success="false" />
         </div>
       </template>
     </sortabletable>

--- a/mixins/vm.js
+++ b/mixins/vm.js
@@ -481,11 +481,10 @@ export default {
 
         if (imageResource?.metadata?.name) {
           _dataVolumeTemplate.spec.pvc.storageClassName = `longhorn-${ imageResource?.metadata?.name }`; // R.storageClassName
-        } else {
-          _dataVolumeTemplate.spec.pvc.storageClassName = '';
+          _dataVolumeTemplate.metadata.annotations = { [HARVESTER_IMAGE_ID]: imageId };
+        } else if (this.pageType !== 'vm') {
+          _dataVolumeTemplate.metadata.annotations = { [HARVESTER_IMAGE_ID]: TEMPORARY_VALUE };
         }
-
-        _dataVolumeTemplate.metadata.annotations = { [HARVESTER_IMAGE_ID]: imageId };
         break;
       }
       }


### PR DESCRIPTION
## Changes

1. add annotation for empty image fields when editing VM template
2. the vm state will be hide when migrating/aborting

## Linked Issues

[https://github.com/rancher/harvester/issues/677](https://github.com/rancher/harvester/issues/677)