### PR TITLE
default to bootorder 1 for initial volume

### DIFF
--- a/mixins/vm.js
+++ b/mixins/vm.js
@@ -201,6 +201,7 @@ export default {
 
       if (_disks.length === 0) {
         out.push({
+          bootOrder:        1,
           source:           SOURCE_TYPE.IMAGE,
           name:             'disk-0',
           accessMode:       'ReadWriteMany',


### PR DESCRIPTION
This sets the bootorder for the initial volume to 1 so it will be choosen by default for boot which is usually what you want.

issue https://github.com/harvester/harvester/issues/734